### PR TITLE
Fix lscpu parsing for missing NUMA nodes

### DIFF
--- a/src/nvmitten/system/system.py
+++ b/src/nvmitten/system/system.py
@@ -59,6 +59,9 @@ class System(Component):
 
         config = list()
         for i, intervals in enumerate(self.cpu.numa_nodes):
+            if intervals is None:
+                continue
+
             cpu_set = set()
             for interval in intervals:
                 cpu_set = cpu_set.union(interval.to_set())

--- a/tests/assets/system_detect_spoofs/cpu/sample-system-2
+++ b/tests/assets/system_detect_spoofs/cpu/sample-system-2
@@ -1,0 +1,393 @@
+{
+
+   "lscpu": [
+
+      {
+
+         "field": "Architecture:",
+
+         "data": "aarch64",
+
+         "children": [
+
+            {
+
+               "field": "CPU op-mode(s):",
+
+               "data": "64-bit"
+
+            },{
+
+               "field": "Byte Order:",
+
+               "data": "Little Endian"
+
+            }
+
+         ]
+
+      },{
+
+         "field": "CPU(s):",
+
+         "data": "144",
+
+         "children": [
+
+            {
+
+               "field": "On-line CPU(s) list:",
+
+               "data": "0-143"
+
+            }
+
+         ]
+
+      },{
+
+         "field": "Vendor ID:",
+
+         "data": "ARM",
+
+         "children": [
+
+            {
+
+               "field": "Model name:",
+
+               "data": "Neoverse-V2",
+
+               "children": [
+
+                  {
+
+                     "field": "Model:",
+
+                     "data": "0"
+
+                  },{
+
+                     "field": "Thread(s) per core:",
+
+                     "data": "1"
+
+                  },{
+
+                     "field": "Core(s) per cluster:",
+
+                     "data": "72"
+
+                  },{
+
+                     "field": "Socket(s):",
+
+                     "data": "-"
+
+                  },{
+
+                     "field": "Cluster(s):",
+
+                     "data": "2"
+
+                  },{
+
+                     "field": "Stepping:",
+
+                     "data": "r0p0"
+
+                  },{
+
+                     "field": "Frequency boost:",
+
+                     "data": "disabled"
+
+                  },{
+
+                     "field": "CPU(s) scaling MHz:",
+
+                     "data": "100%"
+
+                  },{
+
+                     "field": "CPU max MHz:",
+
+                     "data": "3501.0000"
+
+                  },{
+
+                     "field": "CPU min MHz:",
+
+                     "data": "81.0000"
+
+                  },{
+
+                     "field": "BogoMIPS:",
+
+                     "data": "2000.00"
+
+                  },{
+
+                     "field": "Flags:",
+
+                     "data": "fp asimd evtstrm aes pmull sha1 sha2 crc32 atomics fphp asimdhp cpuid asimdrdm jscvt fcma lrcpc dcpop sha3 sm3 sm4 asimddp sha512 sve asimdfhm dit uscat ilrcpc flagm ssbs sb paca pacg dcpodp sve2 sveaes svepmull svebitperm svesha3 svesm4 flagm2 frint svei8mm svebf16 i8mm bf16 dgh bti"
+
+                  }
+
+               ]
+
+            }
+
+         ]
+
+      },{
+
+         "field": "Caches (sum of all):",
+
+         "data": null,
+
+         "children": [
+
+            {
+
+               "field": "L1d:",
+
+               "data": "9 MiB (144 instances)"
+
+            },{
+
+               "field": "L1i:",
+
+               "data": "9 MiB (144 instances)"
+
+            },{
+
+               "field": "L2:",
+
+               "data": "144 MiB (144 instances)"
+
+            },{
+
+               "field": "L3:",
+
+               "data": "228 MiB (2 instances)"
+
+            }
+
+         ]
+
+      },{
+
+         "field": "NUMA:",
+
+         "data": null,
+
+         "children": [
+
+            {
+
+               "field": "NUMA node(s):",
+
+               "data": "16"
+
+            },{
+
+               "field": "NUMA node0 CPU(s):",
+
+               "data": "0-71"
+
+            },{
+
+               "field": "NUMA node1 CPU(s):",
+
+               "data": "72-143"
+
+            },{
+
+               "field": "NUMA node3 CPU(s):",
+
+               "data": null
+
+            },{
+
+               "field": "NUMA node4 CPU(s):",
+
+               "data": null
+
+            },{
+
+               "field": "NUMA node5 CPU(s):",
+
+               "data": null
+
+            },{
+
+               "field": "NUMA node6 CPU(s):",
+
+               "data": null
+
+            },{
+
+               "field": "NUMA node7 CPU(s):",
+
+               "data": null
+
+            },{
+
+               "field": "NUMA node8 CPU(s):",
+
+               "data": null
+
+            },{
+
+               "field": "NUMA node9 CPU(s):",
+
+               "data": null
+
+            },{
+
+               "field": "NUMA node11 CPU(s):",
+
+               "data": null
+
+            },{
+
+               "field": "NUMA node12 CPU(s):",
+
+               "data": null
+
+            },{
+
+               "field": "NUMA node13 CPU(s):",
+
+               "data": null
+
+            },{
+
+               "field": "NUMA node14 CPU(s):",
+
+               "data": null
+
+            },{
+
+               "field": "NUMA node15 CPU(s):",
+
+               "data": null
+
+            },{
+
+               "field": "NUMA node16 CPU(s):",
+
+               "data": null
+
+            },{
+
+               "field": "NUMA node17 CPU(s):",
+
+               "data": null
+
+            }
+
+         ]
+
+      },{
+
+         "field": "Vulnerabilities:",
+
+         "data": null,
+
+         "children": [
+
+            {
+
+               "field": "Gather data sampling:",
+
+               "data": "Not affected"
+
+            },{
+
+               "field": "Itlb multihit:",
+
+               "data": "Not affected"
+
+            },{
+
+               "field": "L1tf:",
+
+               "data": "Not affected"
+
+            },{
+
+               "field": "Mds:",
+
+               "data": "Not affected"
+
+            },{
+
+               "field": "Meltdown:",
+
+               "data": "Not affected"
+
+            },{
+
+               "field": "Mmio stale data:",
+
+               "data": "Not affected"
+
+            },{
+
+               "field": "Reg file data sampling:",
+
+               "data": "Not affected"
+
+            },{
+
+               "field": "Retbleed:",
+
+               "data": "Not affected"
+
+            },{
+
+               "field": "Spec rstack overflow:",
+
+               "data": "Not affected"
+
+            },{
+
+               "field": "Spec store bypass:",
+
+               "data": "Mitigation; Speculative Store Bypass disabled via prctl"
+
+            },{
+
+               "field": "Spectre v1:",
+
+               "data": "Mitigation; __user pointer sanitization"
+
+            },{
+
+               "field": "Spectre v2:",
+
+               "data": "Not affected"
+
+            },{
+
+               "field": "Srbds:",
+
+               "data": "Not affected"
+
+            },{
+
+               "field": "Tsx async abort:",
+
+               "data": "Not affected"
+
+            }
+
+         ]
+
+      }
+
+   ]
+
+}


### PR DESCRIPTION
- Fix lscpu parsing for missing NUMA nodes
- Add support for the case where lscpu stores CPU information under `Vendor ID > Model Name` rather than just under `Vendor ID`