### PR TITLE
Update cupy.py - deprecate old behavior

### DIFF
--- a/src/nvmitten/nvidia/cupy.py
+++ b/src/nvmitten/nvidia/cupy.py
@@ -108,15 +108,8 @@ class _ModuleWrapper:
             return attr
 
 
-# cuda-python was refactored in 12.6.1:
-# https://nvidia.github.io/cuda-python/cuda-bindings/12.6.1/release/12.6.1-notes.html
 import cuda
-import packaging.version as versioning
-if versioning.parse(cuda.__version__) >= versioning.parse("12.6.1"):
-    from cuda.bindings import driver as cuda, runtime as cudart, nvrtc
-else:
-    from cuda import cuda, cudart, nvrtc
-
+from cuda import cuda, cudart, nvrtc
 
 CUDAWrapper = _ModuleWrapper(cuda,
                              cuda.CUresult,

--- a/src/nvmitten/nvidia/cupy.py
+++ b/src/nvmitten/nvidia/cupy.py
@@ -109,7 +109,10 @@ class _ModuleWrapper:
 
 
 import cuda
-from cuda import cuda, cudart, nvrtc
+try:
+    from cuda.bindings import driver as cuda, runtime as cudart, nvrtc
+except AttributeError: # cuda version <= 12.6
+    from cuda import cuda, cudart, nvrtc
 
 CUDAWrapper = _ModuleWrapper(cuda,
                              cuda.CUresult,


### PR DESCRIPTION
The error: 
```
  File "/usr/local/lib/python3.12/dist-packages/nvmitten/nvidia/cupy.py", line 115, in <module>
    if versioning.parse(cuda.__version__) >= versioning.parse("12.6.1"):
                        ^^^^^^^^^^^^^^^^
AttributeError: module 'cuda' has no attribute '__version__'
make: *** [Makefile:54: run_llm_server] Error 1
```

The fix: Try to import assuming cuda version > 12.6. If `AttributeError` is raised, defer to < 12.6 behavior
Except for Pascal and Maxwell architecture, cuda 12.9 supports all other generations. 